### PR TITLE
BREAKING: Internal Traits

### DIFF
--- a/macros/src/approval/simple_multisig.rs
+++ b/macros/src/approval/simple_multisig.rs
@@ -42,7 +42,7 @@ pub fn expand(meta: SimpleMultisigMeta) -> Result<TokenStream, darling::Error> {
     });
 
     Ok(quote! {
-        impl #imp #me::approval::ApprovalManager<
+        impl #imp #me::approval::ApprovalManagerInternal<
                 #action,
                 #me::approval::simple_multisig::ApprovalState,
                 #me::approval::simple_multisig::Configuration<Self>,

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -97,8 +97,8 @@ pub fn derive_pause(input: TokenStream) -> TokenStream {
 
 /// Adds role-based access control. No external methods are exposed.
 ///
-/// The roles prefix must be specify a type using #[rbac(roles = "MyRoles")].
-/// Typically "MyRoles" is an enum and it's variants are the different role
+/// The roles prefix can be specified using `#[rbac(roles = "MyRoles")]`.
+/// Typically `"MyRoles"` is an enum and its variants are the different role
 /// names.
 ///
 /// The storage key prefix for the fields can be optionally specified (default:
@@ -110,7 +110,7 @@ pub fn derive_rbac(input: TokenStream) -> TokenStream {
 
 /// Adds NEP-141 fungible token core functionality to a contract. Exposes
 /// `ft_*` functions to the public blockchain, implements internal controller
-/// and receiver functionality (see: `near_sdk_contract_tools::standard::nep141`).
+/// and receiver functionality (see: [`near_sdk_contract_tools::standard::nep141`]).
 ///
 /// The storage key prefix for the fields can be optionally specified (default:
 /// `"~$141"`) using `#[nep141(storage_key = "<expression>")]`.

--- a/macros/src/owner.rs
+++ b/macros/src/owner.rs
@@ -39,36 +39,36 @@ pub fn expand(meta: OwnerMeta) -> Result<TokenStream, darling::Error> {
     });
 
     Ok(quote! {
-        impl #imp #me::owner::Owner for #ident #ty #wher {
+        impl #imp #me::owner::OwnerInternal for #ident #ty #wher {
             #root
         }
 
         #[#near_sdk::near_bindgen]
         impl #imp #me::owner::OwnerExternal for #ident #ty #wher {
             fn own_get_owner(&self) -> Option<#near_sdk::AccountId> {
-                <Self as #me::owner::Owner>::slot_owner().read()
+                <Self as #me::owner::OwnerInternal>::slot_owner().read()
             }
 
             fn own_get_proposed_owner(&self) -> Option<#near_sdk::AccountId> {
-                <Self as #me::owner::Owner>::slot_proposed_owner().read()
+                <Self as #me::owner::OwnerInternal>::slot_proposed_owner().read()
             }
 
             #[payable]
             fn own_renounce_owner(&mut self) {
                 #near_sdk::assert_one_yocto();
-                self.renounce_owner()
+                #me::owner::Owner::renounce_owner(self);
             }
 
             #[payable]
             fn own_propose_owner(&mut self, account_id: Option<#near_sdk::AccountId>) {
                 #near_sdk::assert_one_yocto();
-                self.propose_owner(account_id);
+                #me::owner::Owner::propose_owner(self, account_id);
             }
 
             #[payable]
             fn own_accept_owner(&mut self) {
                 #near_sdk::assert_one_yocto();
-                self.accept_owner();
+                #me::owner::Owner::accept_owner(self);
             }
         }
     })

--- a/macros/src/pause.rs
+++ b/macros/src/pause.rs
@@ -43,8 +43,6 @@ pub fn expand(meta: PauseMeta) -> Result<TokenStream, darling::Error> {
             #root
         }
 
-        impl #imp #me::pause::Pause for #ident #ty #wher {}
-
         #[#near_sdk::near_bindgen]
         impl #imp #me::pause::PauseExternal for #ident #ty #wher {
             fn paus_is_paused(&self) -> bool {

--- a/macros/src/pause.rs
+++ b/macros/src/pause.rs
@@ -39,9 +39,11 @@ pub fn expand(meta: PauseMeta) -> Result<TokenStream, darling::Error> {
     });
 
     Ok(quote! {
-        impl #imp #me::pause::Pause for #ident #ty #wher {
+        impl #imp #me::pause::PauseInternal for #ident #ty #wher {
             #root
         }
+
+        impl #imp #me::pause::Pause for #ident #ty #wher {}
 
         #[#near_sdk::near_bindgen]
         impl #imp #me::pause::PauseExternal for #ident #ty #wher {

--- a/macros/src/rbac.rs
+++ b/macros/src/rbac.rs
@@ -40,12 +40,10 @@ pub fn expand(meta: RbacMeta) -> Result<TokenStream, darling::Error> {
     });
 
     Ok(quote! {
-        impl #imp #me::rbac::RbacInternal<#roles> for #ident #ty #wher {
-            #root
-        }
-
-        impl #imp #me::rbac::Rbac for #ident #ty #wher {
+        impl #imp #me::rbac::RbacInternal for #ident #ty #wher {
             type Role = #roles;
+
+            #root
         }
     })
 }

--- a/macros/src/rbac.rs
+++ b/macros/src/rbac.rs
@@ -40,10 +40,12 @@ pub fn expand(meta: RbacMeta) -> Result<TokenStream, darling::Error> {
     });
 
     Ok(quote! {
+        impl #imp #me::rbac::RbacInternal<#roles> for #ident #ty #wher {
+            #root
+        }
+
         impl #imp #me::rbac::Rbac for #ident #ty #wher {
             type Role = #roles;
-
-            #root
         }
     })
 }

--- a/macros/src/standard/nep141.rs
+++ b/macros/src/standard/nep141.rs
@@ -54,7 +54,7 @@ pub fn expand(meta: Nep141Meta) -> Result<TokenStream, darling::Error> {
     });
 
     Ok(quote! {
-        impl #imp #me::standard::nep141::Nep141Controller for #ident #ty #wher {
+        impl #imp #me::standard::nep141::Nep141ControllerInternal for #ident #ty #wher {
             #root
         }
 

--- a/src/approval/mod.rs
+++ b/src/approval/mod.rs
@@ -125,9 +125,8 @@ pub enum RemovalError<AuthErr, RemErr> {
     RemovalNotAllowed(RemErr),
 }
 
-/// Collection of action requests that manages their approval state and
-/// execution
-pub trait ApprovalManager<A, S, C>
+/// Internal functions for [`ApprovalManager`]. Using these methods may result in unexpected behavior.
+pub trait ApprovalManagerInternal<A, S, C>
 where
     A: Action<Self> + BorshSerialize + BorshDeserialize,
     S: BorshSerialize + BorshDeserialize + Serialize,
@@ -149,26 +148,79 @@ where
         Self::root().field(ApprovalStorageKey::Config)
     }
 
+    /// Current list of pending action requests.
+    fn slot_request(request_id: u32) -> Slot<ActionRequest<A, S>> {
+        Self::root().field(ApprovalStorageKey::Request(request_id))
+    }
+}
+
+/// Collection of action requests that manages their approval state and
+/// execution
+pub trait ApprovalManager<A, S, C>
+where
+    A: Action<Self> + BorshSerialize + BorshDeserialize,
+    S: BorshSerialize + BorshDeserialize + Serialize,
+    C: ApprovalConfiguration<A, S> + BorshDeserialize + BorshSerialize,
+{
     /// Reads config from storage. Panics if the component has not been
     /// initialized.
+    fn get_config() -> C;
+
+    /// Get a request by ID
+    fn get_request(request_id: u32) -> Option<ActionRequest<A, S>>;
+
+    /// Must be called before using the Approval construct. Can only be called
+    /// once.
+    fn init(config: C);
+
+    /// Creates a new action request initialized with the given approval state
+    fn create_request(
+        &mut self,
+        action: A,
+        approval_state: S,
+    ) -> Result<u32, CreationError<C::AuthorizationError>>;
+
+    /// Executes an action request and removes it from the collection if the
+    /// approval state of the request is fulfilled.
+    fn execute_request(
+        &mut self,
+        request_id: u32,
+    ) -> Result<A::Output, ExecutionError<C::AuthorizationError, C::ExecutionEligibilityError>>;
+
+    /// Is the given request ID able to be executed if such a request were to
+    /// be initiated by an authorized account?
+    fn is_approved_for_execution(request_id: u32) -> Result<(), C::ExecutionEligibilityError>;
+
+    /// Tries to approve the action request designated by the given request ID
+    /// with the given arguments. Panics if the request ID does not exist.
+    fn approve_request(
+        &mut self,
+        request_id: u32,
+    ) -> Result<(), ApprovalError<C::AuthorizationError, C::ApprovalError>>;
+
+    /// Tries to remove the action request indicated by request_id.
+    fn remove_request(
+        &mut self,
+        request_id: u32,
+    ) -> Result<(), RemovalError<C::AuthorizationError, C::RemovalError>>;
+}
+
+impl<T: ApprovalManagerInternal<A, S, C>, A, S, C> ApprovalManager<A, S, C> for T
+where
+    A: Action<Self> + BorshSerialize + BorshDeserialize,
+    S: BorshSerialize + BorshDeserialize + Serialize,
+    C: ApprovalConfiguration<A, S> + BorshDeserialize + BorshSerialize,
+{
     fn get_config() -> C {
         Self::slot_config()
             .read()
             .unwrap_or_else(|| env::panic_str(NOT_INITIALIZED))
     }
 
-    /// Current list of pending action requests.
-    fn slot_request(request_id: u32) -> Slot<ActionRequest<A, S>> {
-        Self::root().field(ApprovalStorageKey::Request(request_id))
-    }
-
-    /// Get a request by ID
     fn get_request(request_id: u32) -> Option<ActionRequest<A, S>> {
         Self::slot_request(request_id).read()
     }
 
-    /// Must be called before using the Approval construct. Can only be called
-    /// once.
     fn init(config: C) {
         require!(
             Self::slot_config().swap(&config).is_none(),
@@ -176,7 +228,6 @@ where
         );
     }
 
-    /// Creates a new action request initialized with the given approval state
     fn create_request(
         &mut self,
         action: A,
@@ -202,8 +253,6 @@ where
         Ok(request_id)
     }
 
-    /// Executes an action request and removes it from the collection if the
-    /// approval state of the request is fulfilled.
     fn execute_request(
         &mut self,
         request_id: u32,
@@ -228,8 +277,6 @@ where
         Ok(result)
     }
 
-    /// Is the given request ID able to be executed if such a request were to
-    /// be initiated by an authorized account?
     fn is_approved_for_execution(request_id: u32) -> Result<(), C::ExecutionEligibilityError> {
         let request = Self::slot_request(request_id).read().unwrap();
 
@@ -237,8 +284,6 @@ where
         config.is_approved_for_execution(&request)
     }
 
-    /// Tries to approve the action request designated by the given request ID
-    /// with the given arguments. Panics if the request ID does not exist.
     fn approve_request(
         &mut self,
         request_id: u32,
@@ -262,7 +307,6 @@ where
         Ok(())
     }
 
-    /// Tries to remove the action request indicated by request_id.
     fn remove_request(
         &mut self,
         request_id: u32,
@@ -300,7 +344,9 @@ mod tests {
 
     use crate::{rbac::Rbac, slot::Slot};
 
-    use super::{Action, ActionRequest, ApprovalConfiguration, ApprovalManager};
+    use super::{
+        Action, ActionRequest, ApprovalConfiguration, ApprovalManager, ApprovalManagerInternal,
+    };
 
     #[derive(BorshSerialize, BorshStorageKey)]
     enum Role {
@@ -347,7 +393,7 @@ mod tests {
         }
     }
 
-    impl ApprovalManager<MyAction, MultisigApprovalState, MultisigConfig> for Contract {
+    impl ApprovalManagerInternal<MyAction, MultisigApprovalState, MultisigConfig> for Contract {
         fn root() -> Slot<()> {
             Slot::new(b"a")
         }

--- a/src/approval/simple_multisig.rs
+++ b/src/approval/simple_multisig.rs
@@ -216,7 +216,7 @@ mod tests {
     use crate::{
         approval::{
             simple_multisig::{AccountAuthorizer, ApprovalState, Configuration},
-            ApprovalManager,
+            ApprovalManager, ApprovalManagerInternal,
         },
         rbac::Rbac,
         slot::Slot,
@@ -250,7 +250,7 @@ mod tests {
     #[near_bindgen]
     struct Contract {}
 
-    impl ApprovalManager<Action, ApprovalState, Configuration<Self>> for Contract {
+    impl ApprovalManagerInternal<Action, ApprovalState, Configuration<Self>> for Contract {
         fn root() -> Slot<()> {
             Slot::new(b"m")
         }

--- a/workspaces-tests/src/bin/simple_multisig.rs
+++ b/workspaces-tests/src/bin/simple_multisig.rs
@@ -13,7 +13,7 @@ use near_sdk_contract_tools::{
     approval::{
         self,
         simple_multisig::{AccountAuthorizer, ApprovalState, Configuration},
-        ApprovalManager,
+        ApprovalManager, ApprovalManagerInternal,
     },
     rbac::Rbac,
     slot::Slot,
@@ -55,7 +55,7 @@ pub struct Contract {}
 
 // This single function implementation completely implements simple multisig on
 // the contract
-impl ApprovalManager<MyAction, ApprovalState, Configuration<Self>> for Contract {
+impl ApprovalManagerInternal<MyAction, ApprovalState, Configuration<Self>> for Contract {
     fn root() -> Slot<()> {
         Slot::new(StorageKey::SimpleMultisig)
     }


### PR DESCRIPTION
Separates functions that are not for regular usage (but are still necessary for the implementation) into another trait so that users can just import the canonically-named trait without worrying about getting functions that might not do what they want.